### PR TITLE
fix: Prisma scripts permission issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "postinstall": "yarn build",
     "build": "yarn workspaces foreach --exclude next-app -pi run build",
     "db-push": "turbo db-push",
-    "generate": "cd packages/db && prisma generate",
-    "studio": " cd packages/db && prisma studio",
+    "generate": "cd packages/db && yarn prisma generate",
+    "studio": " cd packages/db && yarn prisma studio",
     "upgrade:tamagui": "manypkg upgrade tamagui && manypkg upgrade @tamagui && manypkg upgrade tamagui-loader"
   },
   "resolutions": {


### PR DESCRIPTION
For some reason, when I try running `yarn generate` or `yarn studio`, I get `permission denied: prisma`. Adding `yarn` to the scripts seems to fix the issue.

This could be an issue from my side, in which case we can just close this issue.