### PR TITLE
Added vercel config file

### DIFF
--- a/apps/nextjs/vercel.json
+++ b/apps/nextjs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "cd ../.. && yarn run build --filter=nextjs...",
+  "installCommand": "yarn set version stable && yarn install"
+}


### PR DESCRIPTION
I've not tested this but it's a commonly used configuration for these kind of vercel deployment setups.
If this works you will no more fill the "Install command" and "Build command" when deploying to vercel, only the environment variables.