### PR TITLE
Ensure productionApiUrl is used in Expo app

### DIFF
--- a/packages/app/utils/trpc.tsx
+++ b/packages/app/utils/trpc.tsx
@@ -26,6 +26,22 @@ const getBaseUrl = () => {
    * you'll have to manually set it. NOTE: Port 3000 should work for most but confirm
    * you don't have anything else running on it, or you'd have to change it.
    */
+
+  /**
+   * If you're running in production, you'll need to set the productionApiUrl as an
+   * extra field in your expo app.config.ts or app.json. This is because localhost
+   * will not be available in production.
+   */
+  if (!__DEV__) {
+    const productionApiUrl = Constants.manifest?.extra
+      ?.productionApiUrl as string;
+    if (!productionApiUrl)
+      throw new Error(
+        "failed to get productionApiUrl, missing in extra section of app.config.ts",
+      );
+    return productionApiUrl;
+  }
+
   const localhost = Constants.manifest?.debuggerHost?.split(':')[0]
   if (!localhost) throw new Error('failed to get localhost, configure it manually')
   return `http://${localhost}:3000`


### PR DESCRIPTION
When building the Expo app for production localhost will not be avaiable.
Thus, although the app builds and installs on the device, only a blank screen will appear.
Therefore, we must use the production url of the deployed Next.js app.
A good place to store this variable is the Expo manifest.