### PR TITLE
Added acutal dev:tauri script for turborepo

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "serve": "NODE_ENV=production next start --port 8151",
     "lint": "next lint",
-    "export": "next export"
+    "export": "next export",
+    "dev:tauri": "yarn tauri dev"
   },
   "dependencies": {
     "@tamagui/next-theme": "1.0.17",

--- a/turbo.json
+++ b/turbo.json
@@ -19,7 +19,6 @@
     },
     "studio": {
       "inputs": ["prisma/schema.prisma"],
-
       "cache": false
     },
     "build": {


### PR DESCRIPTION
The [previous PR](https://github.com/chen-rn/CUA/pull/31) didn't actually implement the `dev:tauri` script for Turborepo to actually run `yarn tauri dev` when calling the desktop script from the root folder.

As a note the `yarn tauri dev` already builds & exports the Next project before building the Tauri app.