### PR TITLE
Added build scripts to bundle the Tauri app

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -11,7 +11,8 @@
     "serve": "NODE_ENV=production next start --port 8151",
     "lint": "next lint",
     "export": "next export",
-    "dev:tauri": "yarn tauri dev"
+    "dev:tauri": "yarn tauri dev",
+    "build:tauri": "yarn tauri build"
   },
   "dependencies": {
     "@tamagui/next-theme": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postinstall": "yarn build:ui && yarn generate",
     "generate": "cd packages/db && yarn prisma generate",
     "build:ui": "cd packages/ui && yarn build",
+    "build-desktop": "turbo run build:tauri --filter nextjs",
     "studio": " cd packages/db && yarn prisma:studio",
     "upgrade:tamagui": "manypkg upgrade tamagui && manypkg upgrade @tamagui && manypkg upgrade tamagui-loader"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,10 @@
       "dependsOn": ["^db-generate"],
       "cache": false
     },
+    "build:tauri": {
+      "dependsOn": ["^db-generate"],
+      "cache": false
+    },
     "studio": {
       "inputs": ["prisma/schema.prisma"],
       "cache": false


### PR DESCRIPTION
I've gone ahead and implemented a `yarn build-desktop` script to bundle the Tauri app directly from the root folder. It uses turborepo with the usual `db-generate` dependency.

For now this is separated from the main turborepo build script as I cannot test it. When this is tested we can add the `build:tauri` script to the dependencies of the main `build` script.