### PR TITLE
fix(auth): fix saving user to db for email password signup

### DIFF
--- a/packages/app/features/signup/email-verification/screen.tsx
+++ b/packages/app/features/signup/email-verification/screen.tsx
@@ -18,16 +18,16 @@ export function EmailVerificationScreen() {
     await signUp.attemptEmailAddressVerification({ code: verificationCode });
 
     if (signUp.status === "complete") {
+      const { createdSessionId } = signUp;
+      if (createdSessionId) {
+        await setSession(createdSessionId);
+      }
       /* add user id and email into our database */
       createUserMutation.mutate({
         id: signUp.createdUserId!,
         email: signUp.emailAddress!,
       });
       push("/");
-      const { createdSessionId } = signUp;
-      if (createdSessionId) {
-        await setSession(createdSessionId);
-      }
     } else alert("Invalid verification code");
   };
   return (


### PR DESCRIPTION
Fixes an issue with Email/Password signup where the User was saved in Clerk but failed to save in the database due to a `401` auth error on a protected tRPC call. 

Note - the OAuth flow successfully saves a user in both clerk and the database on signup.

The flow now:
1. Sets the session
2. Makes an API call to the protected `user.create` route
3. Pushes back to homescreen

Closes https://github.com/chen-rn/CUA/issues/39