### PR TITLE
General dev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ I recommend you either spin up a Postgres instance on Railway or use Supabase, y
 - `yarn web` to start a web dev server.
 - `yarn native` to run on iOS or Android. **PS**: for this to work, you'll need your web app running on localhost:3000, remember that your NextJS app is also your backend!
 - `yarn studio` to start up your Prisma Studio. **PS**: the tRPC query will show nothing unless you manually open up Prisma and add a "post", or query an user info in the DB!
+- `yarn dev` to start up all packages and applications simultaneously.
 
 ### 3. Adding a new screen
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "schema": "./packages/db/prisma/schema.prisma"
   },
   "scripts": {
+    "dev": "turbo run dev",
     "web": "turbo run dev --filter nextjs",
     "native": "cd apps/expo && yarn dev",
     "desktop": "turbo run dev:tauri --filter nextjs",


### PR DESCRIPTION
This is just an idea; I usually run my project with everything open at once, and only equivalents to the `native` command in this project when I focus in on the native platform (especially if I want the commands and QR-code).

An alternative to a catch-all dev command, that I've done in a similar project for some time, is everything other than Expo as `dev:stack` and Expo itself as `dev:expo`.

Interested in hearing your thoughts. :)