### PR TITLE
No new tab in browser for Prisma

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -13,7 +13,7 @@
     "prisma:migrate:dev": "yarn with-env prisma migrate dev",
     "clean": "rm -rf .turbo node_modules",
     "with-env": "dotenv -e ../../.env --",
-    "dev": "yarn with-env prisma studio --port 5556",
+    "dev": "yarn with-env prisma studio --port 5556 --browser=none",
     "db-push": "yarn with-env prisma db push",
     "db-generate": "yarn with-env prisma generate"
   },


### PR DESCRIPTION
This will make more sense together with my other PR (https://github.com/chen-rn/CUA/pull/46), as this repo defaults to using `yarn studio`.

I find it a bit obnoxious how the dev command opens a new tab every single time, so I prefer having it silent and opening it as needed (like we do with Next.js atm). It may just be me though, so I'm open to hear other's thoughts.