### PR TITLE
feature(ClerkAuthSSR): Enable and provide example of using SSR with Clerk

### DIFF
--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -18,19 +18,19 @@ function MyApp({ Component, pageProps }: SolitoAppProps) {
         <meta name="description" content="Tamagui, Solito, Expo & Next.js" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <ThemeProvider>
+      <ThemeAndAuthProvider pageProps={pageProps}>
         <Component {...pageProps} />
-      </ThemeProvider>
+      </ThemeAndAuthProvider>
     </>
   );
 }
 
-function ThemeProvider({ children }: { children: React.ReactNode }) {
+function ThemeAndAuthProvider({ children, pageProps }: { children: React.ReactNode, pageProps: any }) {
   const [theme, setTheme] = useRootTheme();
 
   return (
     <NextThemeProvider onChangeTheme={setTheme}>
-      <Provider disableRootThemeClass defaultTheme={theme}>
+      <Provider disableRootThemeClass defaultTheme={theme} pageProps={pageProps}>
         {children}
       </Provider>
     </NextThemeProvider>

--- a/apps/nextjs/pages/index.tsx
+++ b/apps/nextjs/pages/index.tsx
@@ -1,3 +1,13 @@
 import { HomeScreen } from 'app/features/home/screen'
+import { buildClerkProps, clerkClient, getAuth } from "@clerk/nextjs/server";
+
+// Use getServerSideProps to get the Clerk user
+// When rendering the page on the server, the Clerk user context will be available immediately in:
+//   <SignedIn, SignedOut, useAuth, useSignIn, useSignUp, useUser> imported from "app/utils/clerk"
+export const getServerSideProps = async ({ req }: any) => {
+  const { userId } = getAuth(req);
+  const user = userId ? await clerkClient.users.getUser(userId) : undefined;
+  return { props: { ...buildClerkProps(req, { user }) } };
+};
 
 export default HomeScreen

--- a/packages/app/provider/auth/index.tsx
+++ b/packages/app/provider/auth/index.tsx
@@ -3,7 +3,7 @@ import { tokenCache } from "./cache";
 
 const frontendApi = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children }: { children: React.ReactNode, pageProps?: any }) {
   if (typeof frontendApi === "undefined")
     throw new Error(
       "Clerk API key not found. Please add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY to your .env file."

--- a/packages/app/provider/auth/index.web.tsx
+++ b/packages/app/provider/auth/index.web.tsx
@@ -1,5 +1,5 @@
 import { ClerkProvider } from '@clerk/nextjs'
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  return <ClerkProvider>{children}</ClerkProvider>
+export function AuthProvider({ children, pageProps }: { children: React.ReactNode, pageProps?: any }) {
+  return <ClerkProvider {...pageProps}>{children}</ClerkProvider>
 }

--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -3,9 +3,9 @@ import { TamaguiProvider, TamaguiProviderProps } from '@my/ui'
 import { AuthProvider } from './auth'
 import { TRPCProvider } from './trpc' //mobile only
 
-export function Provider({ children, ...rest }: Omit<TamaguiProviderProps, 'config'>) {
+export function Provider({ children, pageProps, ...rest }: Omit<TamaguiProviderProps, 'config'> & { pageProps?: any }) {
   return (
-    <AuthProvider>
+    <AuthProvider pageProps={pageProps}>
       <TamaguiProvider config={config} disableInjectCSS defaultTheme="light" {...rest}>
           <TRPCProvider>{children}</TRPCProvider>
       </TamaguiProvider>


### PR DESCRIPTION
By passing `pageProps` through to `ClerkProvider`, all the functions in `app/utils/clerk` will have an initial context set and will resolve immediately during server side render.

I've also provided an example in `nextjs/pages/home` of a `getServerSideProps` that includes the necessary context in `pageProps`. The result is that the `Sign Out` button doesn't pop in when loading the Home page.

I've implemented this in my own project and figured some others wouldn't mind the help getting it set up.

LMK if there is a better or standard way to do this ofc.