### PR TITLE
[BUG] Fixed Tamagui web css

### DIFF
--- a/apps/nextjs/pages/_app.tsx
+++ b/apps/nextjs/pages/_app.tsx
@@ -17,6 +17,11 @@ function MyApp({ Component, pageProps }: SolitoAppProps) {
         <title>Universal Example</title>
         <meta name="description" content="Tamagui, Solito, Expo & Next.js" />
         <link rel="icon" href="/favicon.ico" />
+        <style>{`
+          body, #root, #__next {
+            min-width: 100% !important;
+          }
+        `}</style>
       </Head>
       <ThemeProvider>
         <Component {...pageProps} />


### PR DESCRIPTION
![2023-07-16 12_34_27-](https://github.com/chen-rn/CUA/assets/57916483/99f9ded0-2e21-4f55-86a0-979a67aff615)

I added a small css fix for the horizontal scrollbar. Currently the horizontal scrollbar appears whenever the vertical one does (as you can see in the picture), but that's not the intended behaviour. This fix worked over at t4-app (in [this](https://github.com/timothymiller/t4-app/commit/10e8e9ab00fddb798309554fb55743e63e588ec2) commit) so it's already tested for this case.

With the fix applied it looks like this:

![2023-07-16 12_46_10-](https://github.com/chen-rn/CUA/assets/57916483/870b678d-2e3e-48f4-8d07-148d816e6b10)
